### PR TITLE
Fixed the test order to correctly concat the files prior to qunit

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,8 +52,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-concat');
 
-  grunt.registerTask('test', ['jshint', 'qunit']);
-
-  grunt.registerTask('default', ['jshint', 'qunit', 'concat', 'uglify']);
+  grunt.registerTask('test', ['jshint', 'concat', 'qunit']);
+  grunt.registerTask('default', ['test', 'uglify']);
 
 };


### PR DESCRIPTION
Hey,

Came across your project and went to build it for the first time and found that it errors due to qunit relying on the output of the concat task. 

There was also an issue where changes to the mentonify.js source file would not get picked up until the second time running `grunt test`

Finally as the default task now contains all the sub tasks of the test task I've combined them for easier management.

Hope this is ok.

Thanks,
.FxN
